### PR TITLE
chore: Add standard issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/standard-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/standard-issue-template.md
@@ -1,0 +1,14 @@
+---
+name: Standard Issue Template
+about: My blueprint to generate issues for beginner developer assistance
+title: "<type>: Issue summary"
+labels: ''
+assignees: ''
+
+---
+
+Description here
+
+branch suggestion: `<type>/<short-description-dash-separated>`
+commit suggestion: `<type>: <issue #> - <commit message>`
+__we like to see [conventional commits](https://www.conventionalcommits.org)__


### PR DESCRIPTION
This is mostly for me (RackReaver) as I like to make it easy for beginner developers to commit to my repo and they need basic information to feel confident to make a pull request to the repo.